### PR TITLE
Make difference between examples more apparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ To command a closure to move in a particular manner, add an 'On' effect and adju
 
         <img src="/images/ord_channel_not_ok.png?raw=true" width="900" />
 
-    - This example will cause the Aux Park lights to flash on Model 3/Y:
+    - This example will cause the Aux Park lights to flash on Model 3/Y (note the blank time between each box compared to the other example):
 
         <img src="/images/ord_channel_ok.png?raw=true" width="900" />
 


### PR DESCRIPTION
In https://github.com/teslamotors/light-show#light-channel-mapping-recommendations the difference between the examples takes a bit to see. Adding some additional text to one or the other to help make it apparent would help people see it and understand the point of the two examples better.